### PR TITLE
feat: mount graphite config directory from host

### DIFF
--- a/functions
+++ b/functions
@@ -71,6 +71,12 @@ service_create_container() {
 
   local network_alias="$(service_dns_hostname "$SERVICE")"
 
+  if [[ -z "$(ls -A "$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX" 2>/dev/null)" ]]; then
+    "$DOCKER_BIN" container create --name "${SERVICE_NAME}-conf-extract" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" true >/dev/null 2>&1
+    "$DOCKER_BIN" cp "${SERVICE_NAME}-conf-extract:/opt/graphite/conf/." "$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/" 2>/dev/null || true
+    "$DOCKER_BIN" rm "${SERVICE_NAME}-conf-extract" >/dev/null 2>&1
+  fi
+
   rm -f "$SERVICE_ROOT/ID"
   declare -a DOCKER_ARGS
   DOCKER_ARGS=()
@@ -84,6 +90,7 @@ service_create_container() {
   DOCKER_ARGS+=("--restart=always")
   DOCKER_ARGS+=("--volume=$SERVICE_HOST_ROOT/data/grafana:/opt/grafana/data")
   DOCKER_ARGS+=("--volume=$SERVICE_HOST_ROOT/data/whisper:/opt/graphite/storage/whisper")
+  DOCKER_ARGS+=("--volume=$SERVICE_HOST_ROOT/config:/opt/graphite/conf")
 
   declare -a LINK_CONTAINER_DOCKER_ARGS
   LINK_CONTAINER_DOCKER_ARGS=()


### PR DESCRIPTION
## Summary

- Bind-mount the service config directory (`config/`) into `/opt/graphite/conf` so custom config files (e.g. `storage-schemas.conf`) placed there take effect
- On first container creation, seed the host config directory with the image defaults so the bind mount doesn't overlay with an empty directory

## Problem

The plugin creates a config directory on service create and reports it via `graphite:info --config-dir`, but never mounts it into the container. Custom config files placed there have no effect ([#50](https://github.com/dokku/dokku-graphite/issues/50)).

This was originally noted in commit `b0d8f38` ("prepare ground for config directory changes") from 2017, but it looks like the mount was never added.